### PR TITLE
TASK: Add no_log to user task

### DIFF
--- a/tasks/users.yaml
+++ b/tasks/users.yaml
@@ -17,3 +17,4 @@
   with_subelements:
     - "{{ mariadb.users.values()|mariadb_subelem_dicts_to_list('hosts') }}"
     - hosts
+  no_log: True


### PR DESCRIPTION
This removes a warning when running the users task and hides output of sensible user data