### PR TITLE
PIT-2590: fix garb working dir (base_dir) for FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,13 @@ Handles database creation, user management and optional automated backups.
 |---|---|---|---|---|
 | `config` | Parent directory that will contain `conf.d`/`mariadb.conf.d`. Change this only when using custom filesystem layouts. | str | no | {% if ansible_facts['system'] == 'Linux' %}/etc/mysql{% else %}/usr/local/etc/mysql{% endif %} |
 | `lib` | Data directory used by MariaDB (e.g. for grastate.dat on Galera nodes). Linux uses `/var/lib/mysql`; FreeBSD uses `/var/db/mysql`. | str | no | {% if ansible_facts['system'] == 'Linux' %}/var/lib/mysql{% else %}/var/db/mysql{% endif %} |
+| `garb` | Settings for the garbd arbitrator service. | dict of 'garb' options | no | {} |
+
+#### Options for `mariadb.prefix.garb`
+
+|Option|Description|Type|Required|Default|
+|---|---|---|---|---|
+| `working_directory` | Working directory used for the garbd arbitrator service. Linux uses `/var/lib/garbd`; FreeBSD uses `/var/db/garbd`. | str | no | {% if ansible_facts['system'] == 'Linux' %}/var/lib/garbd{% else %}/var/db/garbd{% endif %} |
 
 #### Options for `mariadb.repository`
 

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -16,6 +16,13 @@ mariadb:
       {%- else -%}
         /var/db/mysql
       {%- endif -%}
+    garb:
+      working_directory: >-
+        {%- if ansible_facts['system'] == 'Linux' -%}
+          /var/lib/garbd
+        {%- else -%}
+          /var/db/garbd
+        {%- endif -%}
   socket: >-
     {%- if ansible_facts['system'] == 'Linux' -%}
       /run/mysqld/mysqld.sock
@@ -79,10 +86,3 @@ mariadb_galera_cluster_nodes: >-
       {%- set _ = cluster_nodes.append(node) -%}
     {%- endif -%}
   {%- endfor -%}
-  {{- cluster_nodes -}}
-mariadb_garb_working_directory: >-
-  {%- if ansible_facts['system'] == 'Linux' -%}
-    /var/lib/garbd
-  {%- else -%}
-    /var/db/garbd
-  {%- endif -%}

--- a/defaults/main.yaml
+++ b/defaults/main.yaml
@@ -80,3 +80,9 @@ mariadb_galera_cluster_nodes: >-
     {%- endif -%}
   {%- endfor -%}
   {{- cluster_nodes -}}
+mariadb_garb_working_directory: >-
+  {%- if ansible_facts['system'] == 'Linux' -%}
+    /var/lib/garbd
+  {%- else -%}
+    /var/db/garbd
+  {%- endif -%}

--- a/meta/argument_specs.yml
+++ b/meta/argument_specs.yml
@@ -46,6 +46,19 @@ argument_specs:
                 description:
                   - Data directory used by MariaDB (e.g. for grastate.dat on Galera nodes).
                   - Linux uses `/var/lib/mysql`; FreeBSD uses `/var/db/mysql`.
+              garb:
+                type: dict
+                default: {}
+                description:
+                  - Settings for the garbd arbitrator service.
+                options:
+                  working_directory:
+                    type: str
+                    default: >-
+                      {% if ansible_facts['system'] == 'Linux' %}/var/lib/garbd{% else %}/var/db/garbd{% endif %}
+                    description:
+                      - Working directory used for the garbd arbitrator service.
+                      - Linux uses `/var/lib/garbd`; FreeBSD uses `/var/db/garbd`.
           socket:
             type: str
             default: >-

--- a/tasks/galera.yaml
+++ b/tasks/galera.yaml
@@ -105,7 +105,7 @@
       block:
         - name: Create garb working directory
           ansible.builtin.file:
-            path: "{{ '/var/lib/garbd' if ansible_facts['system'] == 'Linux' else '/var/db/garbd' }}"
+            path: "{{ mariadb_garb_working_directory }}"
             owner: nobody
             group: "{{ 'nogroup' if ansible_facts['system'] == 'Linux' else 'nobody' }}"
             mode: 0755
@@ -119,7 +119,7 @@
             path: /usr/lib/systemd/system/garb.service
             regexp: "^WorkingDirectory"
             insertafter: "^ExecStart=.*"
-            line: "WorkingDirectory=/var/lib/garbd"
+            line: "WorkingDirectory={{ mariadb_garb_working_directory }}"
 
         - name: Set service name fact
           ansible.builtin.set_fact:

--- a/tasks/galera.yaml
+++ b/tasks/galera.yaml
@@ -105,7 +105,7 @@
       block:
         - name: Create garb working directory
           ansible.builtin.file:
-            path: "{{ mariadb_garb_working_directory }}"
+            path: "{{ mariadb.prefix.garb.working_directory }}"
             owner: nobody
             group: "{{ 'nogroup' if ansible_facts['system'] == 'Linux' else 'nobody' }}"
             mode: 0755
@@ -119,7 +119,7 @@
             path: /usr/lib/systemd/system/garb.service
             regexp: "^WorkingDirectory"
             insertafter: "^ExecStart=.*"
-            line: "WorkingDirectory={{ mariadb_garb_working_directory }}"
+            line: "WorkingDirectory={{ mariadb.prefix.garb.working_directory }}"
 
         - name: Set service name fact
           ansible.builtin.set_fact:

--- a/templates/rc.conf.d/garb
+++ b/templates/rc.conf.d/garb
@@ -1,5 +1,5 @@
 garb_enable=YES
 garb_galera_nodes="{{ mariadb['my.cnf'].mysqld.wsrep_cluster_address | regex_replace('gcomm://', '') | regex_replace(',', ':4567 ') | regex_replace('$', ':4567') }}"
 garb_galera_group={{ mariadb['my.cnf'].mysqld.wsrep_cluster_name }}
+garb_galera_options="base_dir={{ mariadb_garb_working_directory }}"
 garb_log_file=/var/log/garb/garb.log
-garb_datadir=/var/db/garbd

--- a/templates/rc.conf.d/garb
+++ b/templates/rc.conf.d/garb
@@ -1,5 +1,5 @@
 garb_enable=YES
 garb_galera_nodes="{{ mariadb['my.cnf'].mysqld.wsrep_cluster_address | regex_replace('gcomm://', '') | regex_replace(',', ':4567 ') | regex_replace('$', ':4567') }}"
 garb_galera_group={{ mariadb['my.cnf'].mysqld.wsrep_cluster_name }}
-garb_galera_options="base_dir={{ mariadb_garb_working_directory }}"
+garb_galera_options="base_dir={{ mariadb.prefix.garb.working_directory }}"
 garb_log_file=/var/log/garb/garb.log


### PR DESCRIPTION
Found the real FreeBSD config var base_dir for the WorkingDIrectory equivalent of Linux.
Additionally minor clean up chore with defaults.
